### PR TITLE
ci(issue-0000): add pull request quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,47 +1,60 @@
 name: CI
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
-      - '**' # Run on any branch
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-test:
+  quality-gate:
+    name: Pull request quality gate
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
-    # supply environment variables from GitHub Secrets so tests run with real config
     env:
-      NODE_ENV: test           # ensures dotenv won't try to load development file
-      DB_URI: ${{ secrets.DB_URI }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      NODE_ENV: test
+      DB_URI: mongodb://127.0.0.1:27017/authms_test
+      JWT_SECRET: test-only-ci-secret-that-is-never-used-in-production
 
     steps:
-      # Checkout the repository code
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Set up Node.js environment
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: npm
 
-      # Install npm dependencies
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
-      # Run lint checks
-      - name: Run ESLint
+      - name: Run lint
         run: npm run lint
 
-      # Run unit tests
+      - name: Build TypeScript
+        run: npm run build
+
       - name: Run unit tests
         run: npm run test:unit
 
-      # Run integration tests
       - name: Run integration tests
         run: npm run test:integration
 
-      # Run security audit (only fail on critical vulnerabilities)
-      - name: Run npm audit
-        run: npm audit --audit-level=critical || true
+      - name: Build Docker image
+        run: docker compose build
+
+      # Critical vulnerabilities should block merges; lower severities are reviewed separately.
+      - name: Audit critical vulnerabilities
+        run: npm audit --audit-level=critical

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   quality-gate:
-    name: Pull request quality gate
+    name: CI quality gate
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -52,9 +52,9 @@ jobs:
       - name: Run integration tests
         run: npm run test:integration
 
-      - name: Build Docker image
-        run: docker compose build
-
       # Critical vulnerabilities should block merges; lower severities are reviewed separately.
       - name: Audit critical vulnerabilities
         run: npm audit --audit-level=critical
+
+      - name: Build Docker image
+        run: docker compose build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,10 @@
 npx lint-staged
+
+branch="$(git branch --show-current)"
+
+if [ "$branch" = "main" ]; then
+  echo "Direct commits to main are not allowed."
+  echo "Create a feature branch first:"
+  echo "git switch -c feature/your-feature-name"
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting and secret-handling g
 - [OpenAPI Specification](docs/api/openapi.yaml)
 - [Database Collections](docs/database/collections.md)
 - [Docker Guide](docs/development/docker.md)
+- [Continuous Integration](docs/development/ci.md)
 - [Testing Strategy](docs/development/testing.md)
 - [Release Process](docs/development/release-process.md)
 - [Security Design](docs/security/overview.md)

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See [API Reference](docs/api/reference.md) and [OpenAPI Specification](docs/api/
 | `npm run lint`             | Run ESLint                                           |
 | `npm run lint:fix`         | Run ESLint with automatic fixes                      |
 | `npm run format`           | Format project files with Prettier                   |
-| `npm run load-env`         | Print resolved environment configuration             |
+| `npm run load-env`         | Print masked environment configuration               |
 | `npm run release`          | Generate a standard-version release                  |
 
 ## Testing

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -16,7 +16,7 @@ CI runs on:
 
 Runs for the same branch or pull request are grouped with concurrency, so an older run is cancelled when a newer commit is pushed.
 
-Branch protection or a GitHub repository ruleset must separately require this CI status check before merging. The workflow reports the check result, but repository settings decide whether a failing check blocks the merge button.
+Branch protection or a GitHub repository ruleset must separately require the `CI / CI quality gate` status check before merging. The workflow reports the check result, but repository settings decide whether a failing check blocks the merge button.
 
 ## Quality Gate
 

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -11,10 +11,12 @@ AuthMS uses GitHub Actions as a pull-request quality gate. The workflow lives at
 CI runs on:
 
 - Pull requests targeting `main`
-- Pushes to `main`
+- Changes pushed or merged into `main`
 - Manual runs from the GitHub Actions tab
 
 Runs for the same branch or pull request are grouped with concurrency, so an older run is cancelled when a newer commit is pushed.
+
+Branch protection or a GitHub repository ruleset must separately require this CI status check before merging. The workflow reports the check result, but repository settings decide whether a failing check blocks the merge button.
 
 ## Quality Gate
 
@@ -31,8 +33,8 @@ npm run lint
 npm run build
 npm run test:unit
 npm run test:integration
-docker compose build
 npm audit --audit-level=critical
+docker compose build
 ```
 
 The audit step fails CI only for critical vulnerabilities. Lower-severity findings should still be reviewed, but they do not block the pull-request gate by default.

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -1,0 +1,54 @@
+# Continuous Integration
+
+AuthMS uses GitHub Actions as a pull-request quality gate. The workflow lives at:
+
+```text
+.github/workflows/ci.yml
+```
+
+## When CI Runs
+
+CI runs on:
+
+- Pull requests targeting `main`
+- Pushes to `main`
+- Manual runs from the GitHub Actions tab
+
+Runs for the same branch or pull request are grouped with concurrency, so an older run is cancelled when a newer commit is pushed.
+
+## Quality Gate
+
+The CI job runs on Ubuntu with Node.js 22 and installs dependencies with:
+
+```bash
+npm ci
+```
+
+Checks run in this order:
+
+```bash
+npm run lint
+npm run build
+npm run test:unit
+npm run test:integration
+docker compose build
+npm audit --audit-level=critical
+```
+
+The audit step fails CI only for critical vulnerabilities. Lower-severity findings should still be reviewed, but they do not block the pull-request gate by default.
+
+## Test Configuration
+
+CI uses test-only placeholder environment values:
+
+```text
+NODE_ENV=test
+DB_URI=mongodb://127.0.0.1:27017/authms_test
+JWT_SECRET=test-only-ci-secret-that-is-never-used-in-production
+```
+
+The integration tests use `mongodb-memory-server`, so they do not require a real external MongoDB instance or GitHub Secrets.
+
+## Docker Build
+
+The Docker build validates that the production image can be built from the current source. The Compose stack receives the CI-only JWT placeholder through the workflow environment so no real runtime secret is required.

--- a/scripts/load-env.ts
+++ b/scripts/load-env.ts
@@ -17,7 +17,26 @@ if (result.error) {
 
 console.log(`Loaded environment variables from .env.${env}`);
 console.log('Current variables:');
-// print only a whitelist so we don't accidentally log secrets
-['NODE_ENV', 'PORT', 'DB_URI', 'JWT_SECRET'].forEach((key) => {
-  console.log(`${key}=${process.env[key]}`);
+
+const formatValue = (key: string, value: string | undefined): string => {
+  if (!value) {
+    return '<not set>';
+  }
+
+  if (key === 'DB_URI' || key === 'JWT_SECRET') {
+    return '<set>';
+  }
+
+  return value;
+};
+
+const variables = [
+  { key: 'NODE_ENV', value: process.env.NODE_ENV },
+  { key: 'PORT', value: process.env.PORT },
+  { key: 'DB_URI', value: process.env.DB_URI },
+  { key: 'JWT_SECRET', value: process.env.JWT_SECRET },
+];
+
+variables.forEach(({ key, value }) => {
+  console.log(`${key}=${formatValue(key, value)}`);
 });


### PR DESCRIPTION
## Summary

Updates the AuthMS GitHub Actions CI workflow into a pull-request quality gate for `main`.

## Changes

- Run CI on pull requests to `main`, pushes to `main`, and manual workflow dispatch
- Add minimal workflow permissions with `contents: read`
- Add concurrency cancellation for outdated runs
- Use Node.js 22 with npm caching via `actions/setup-node@v4`
- Replace `npm ci --legacy-peer-deps` with `npm ci`
- Use safe test-only CI environment values instead of GitHub Secrets
- Add TypeScript build and Docker Compose build checks
- Replace hidden audit failures with a critical-only audit gate
- Add CI documentation under `docs/development/ci.md`

## Validation

- `npm.cmd ci --ignore-scripts --dry-run`
- `npm.cmd run lint`
- `npm.cmd run build`
- `npm.cmd run test:unit`
- `npm.cmd run test:integration`
- `docker compose build`
- `npm.cmd audit --audit-level=critical`

## Notes

`npm audit` still reports non-critical vulnerabilities, but there are no critical vulnerabilities currently blocking CI.