### PR TITLE
docs(issue-0000): add MkDocs documentation site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm ci
 
       - name: Install documentation dependencies
-        run: python -m pip install -r requirements-docs.txt        
+        run: python -m pip install -r requirements-docs.txt
 
       - name: Run lint
         run: npm run lint
@@ -68,9 +68,6 @@ jobs:
       # Critical vulnerabilities should block merges; lower severities are reviewed separately.
       - name: Audit critical vulnerabilities
         run: npm audit --audit-level=critical
-
-      - name: Build documentation
-        run: docker run --rm -v "${{ github.workspace }}:/docs" squidfunk/mkdocs-material:9 build --strict
 
       - name: Build Docker image
         run: docker compose build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,27 @@ jobs:
           node-version: '22'
           cache: npm
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Install documentation dependencies
+        run: python -m pip install -r requirements-docs.txt        
 
       - name: Run lint
         run: npm run lint
 
       - name: Build TypeScript
         run: npm run build
+
+      - name: Validate documentation
+        run: mkdocs build --strict
 
       - name: Run unit tests
         run: npm run test:unit
@@ -55,6 +68,9 @@ jobs:
       # Critical vulnerabilities should block merges; lower severities are reviewed separately.
       - name: Audit critical vulnerabilities
         run: npm audit --audit-level=critical
+
+      - name: Build documentation
+        run: docker run --rm -v "${{ github.workspace }}:/docs" squidfunk/mkdocs-material:9 build --strict
 
       - name: Build Docker image
         run: docker compose build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,69 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/documentation.yml'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install documentation dependencies
+        run: python -m pip install -r requirements-docs.txt
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    name: Deploy documentation
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,9 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# MkDocs generated site
+site/
+
+# Optional local Python environment
+.venv-docs/

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -20,10 +20,16 @@ Branch protection or a GitHub repository ruleset must separately require the `CI
 
 ## Quality Gate
 
-The CI job runs on Ubuntu with Node.js 22 and installs dependencies with:
+The CI job runs on Ubuntu with Node.js 22 and Python 3.13. Application dependencies are installed with:
 
 ```bash
 npm ci
+```
+
+Documentation dependencies are installed with:
+
+```bash
+python -m pip install -r requirements-docs.txt
 ```
 
 Checks run in this order:
@@ -31,6 +37,7 @@ Checks run in this order:
 ```bash
 npm run lint
 npm run build
+mkdocs build --strict
 npm run test:unit
 npm run test:integration
 npm audit --audit-level=critical
@@ -54,3 +61,7 @@ The integration tests use `mongodb-memory-server`, so they do not require a real
 ## Docker Build
 
 The Docker build validates that the production image can be built from the current source. The Compose stack receives the CI-only JWT placeholder through the workflow environment so no real runtime secret is required.
+
+## Documentation Build
+
+The documentation check validates the MkDocs site with strict mode. Broken links, missing navigation entries, or invalid MkDocs configuration should fail CI before merge.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,79 @@
+# AuthMS Documentation
+
+AuthMS is the authentication microservice for Maktab Pro. It provides user registration, login and JSON Web Token verification through an Express API backed by MongoDB.
+
+## Start here
+
+- [Architecture overview](architecture/overview.md)
+- [API reference](api/reference.md)
+- [Database collections](database/collections.md)
+- [Docker development](development/docker.md)
+- [Testing strategy](development/testing.md)
+- [Continuous integration](development/ci.md)
+- [Release process](development/release-process.md)
+- [Security overview](security/overview.md)
+
+## Responsibilities
+
+AuthMS is responsible for:
+
+- Registering users
+- Hashing passwords before persistence
+- Authenticating credentials
+- Issuing signed JSON Web Tokens
+- Verifying bearer tokens
+- Storing authentication records in MongoDB
+- Exposing a health-check endpoint
+
+## Service boundaries
+
+AuthMS does not own:
+
+- User profile information
+- Student or teacher records
+- Maktab membership
+- Billing
+- Notifications
+- Application-specific permissions outside authentication
+
+These responsibilities belong to other services within the Maktab Pro platform.
+
+## Architecture
+
+AuthMS follows a controller-service-repository structure:
+
+```text
+Client
+  → Express route
+  → Controller
+  → Service
+  → Repository
+  → MongoDB
+```
+
+This separation keeps HTTP handling, authentication logic and persistence concerns independently testable.
+
+## API
+
+The HTTP API includes:
+
+- User registration
+- User login
+- Bearer-token verification
+- Service health checks
+
+See the [API reference](api/reference.md) for request and response examples.
+
+The machine-readable API contract is maintained in `api/openapi.yaml`.
+
+## Development
+
+Developers should use feature branches and submit changes through pull requests into `main`. The CI quality gate validates linting, compilation, tests, dependency security and the Docker build before changes can be merged.
+
+See the [continuous integration guide](development/ci.md) for details.
+
+## Security
+
+Passwords are hashed before storage, authentication errors avoid revealing which credential was incorrect, and secrets must be supplied through environment configuration rather than committed to the repository.
+
+See the [security overview](security/overview.md) and the repository `SECURITY.md` policy for further guidance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
+
+site_name: AuthMS Documentation
+site_description: Technical documentation for the AuthMS authentication microservice
+site_url: https://amin-newcastle.github.io/authMS/
+
+repo_name: amin-newcastle/authMS
+repo_url: https://github.com/amin-newcastle/authMS
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+
+  features:
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.superfences
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+
+  - Architecture:
+      - Overview: architecture/overview.md
+
+  - API:
+      - Reference: api/reference.md
+
+  - Database:
+      - Collections: database/collections.md
+
+  - Development:
+      - Continuous Integration: development/ci.md
+      - Docker: development/docker.md
+      - Testing: development/testing.md
+      - Release Process: development/release-process.md
+
+  - Security:
+      - Overview: security/overview.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+requirements-docs.txt

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,1 @@
-requirements-docs.txt
+mkdocs-material>=9,<10


### PR DESCRIPTION
## Summary

Finalises the AuthMS CI quality gate and adds documentation validation support.

## Changes

- Add Python setup with pip caching for documentation tooling
- Install documentation dependencies from `requirements-docs.txt`
- Validate MkDocs documentation with a strict build
- Keep CI focused on pull requests to `main`, pushes to `main`, and manual runs
- Preserve critical vulnerability blocking with `npm audit --audit-level=critical`
- Mask sensitive values in the environment helper output
- Clarify CI documentation and branch protection expectations

## Validation

- `npx.cmd prettier --check .github/workflows/ci.yml`
- `npm.cmd run lint`
- `npm.cmd run build`
- `npm.cmd run test:unit`
- `npm.cmd run test:integration`
- `npm.cmd audit --audit-level=critical`
- `docker run --rm -v "${PWD}:/docs" squidfunk/mkdocs-material:9 build --strict`
- `docker compose build`

## Notes

CI still reports existing non-blocking lint warnings around console usage. `npm audit` reports non-critical vulnerabilities, but no critical vulnerabilities.