### PR TITLE
ci(issue-0000): fix documentation workflow concurrency name

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: github-pages
+  group: pages
   cancel-in-progress: false
 
 jobs:
@@ -60,7 +60,7 @@ jobs:
       id-token: write
 
     environment:
-      name: github-pages
+      name: 'github-pages'
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:


### PR DESCRIPTION
Updates the documentation deployment workflow so the concurrency group uses a neutral pages name while keeping the GitHub Pages deployment environment as github-pages.

Changes
- Renamed the documentation workflow concurrency group from github-pages to pages
- Kept the deploy environment as 'github-pages', which is the expected GitHub Pages environment
- Formatted documentation.yml with Prettier

Validation
- npx.cmd prettier --check .github/workflows/documentation.yml passed

Notes
This change is workflow-only and does not affect AuthMS application code or documentation content.