### PR TITLE
docs(issue-0000): add contributor and pull request guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+## Summary
+
+<!-- Briefly describe what changed and why. -->
+
+## Related issue
+
+<!-- Link the issue, ticket, or context. Use "None" if not applicable. -->
+
+## Type of change
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Test
+- [ ] CI/CD
+- [ ] Refactor
+- [ ] Chore
+
+## Implementation details
+
+<!-- Note important design choices, affected endpoints, data changes, or tradeoffs. -->
+
+## Testing completed
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm run test:unit`
+- [ ] `npm run test:integration`
+- [ ] `npm audit --audit-level=critical`
+- [ ] `docker compose build`
+- [ ] `mkdocs build --strict` where documentation changed
+
+## Security considerations
+
+<!-- Describe auth, JWT, password, secret, logging, dependency, or data exposure impact. Use "None" if not applicable. -->
+
+## Documentation changes
+
+<!-- List README, MkDocs, OpenAPI, or security docs updated. Use "None" if not applicable. -->
+
+## Reviewer notes
+
+<!-- Call out anything reviewers should focus on. Screenshots are optional and only needed where visual output is relevant. -->
+
+## Final checklist
+
+- [ ] This branch was created from current `main`
+- [ ] No secrets, tokens, credentials, or `.env` files were committed
+- [ ] Code was linted
+- [ ] TypeScript compiled
+- [ ] Unit tests passed
+- [ ] Integration tests passed
+- [ ] Documentation was updated where needed
+- [ ] `mkdocs build --strict` passed where documentation changed
+- [ ] Docker still builds
+- [ ] The change is focused and does not include unrelated refactoring

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,305 @@
+# Contributing to AuthMS
+
+Thank you for contributing to AuthMS. This guide explains the expected workflow for making focused, reviewable changes to the authentication microservice.
+
+## Code of Conduct Expectations
+
+AuthMS does not currently have a separate `CODE_OF_CONDUCT.md`, but contributors are expected to keep discussions professional, respectful, and useful.
+
+- Be clear and constructive in issues, pull requests, and code review.
+- Assume good intent, but ask for clarification when something is unclear.
+- Keep review comments about the code, tests, documentation, and security impact.
+- Do not post real credentials, JWTs, database URIs, tokens, or exploit details in public issues or pull requests.
+- Report security vulnerabilities privately through the process in `SECURITY.md`.
+
+## Prerequisites
+
+Install the following before working locally:
+
+- Git
+- Node.js 18 or newer
+- npm
+- Docker Desktop with Docker Compose
+- Python 3.13 and pip, for local documentation validation
+
+The Docker image currently uses `node:18-alpine`. CI validates the service with Node.js 22 and Python 3.13.
+
+## Local Project Setup
+
+From the repository root:
+
+```bash
+npm ci
+```
+
+If Husky hooks are not installed after dependency installation, run:
+
+```bash
+npm run prepare
+```
+
+Start the TypeScript development server with:
+
+```bash
+npm run dev
+```
+
+Build and run compiled output with:
+
+```bash
+npm run build
+npm start
+```
+
+To run the Docker Compose stack:
+
+```bash
+docker compose up --build -d
+```
+
+Stop the stack with:
+
+```bash
+docker compose down
+```
+
+## Environment Configuration
+
+Create local environment files from the documented examples, not from real shared credentials. Real `.env` files must not be committed.
+
+Required runtime values:
+
+```text
+NODE_ENV=development
+PORT=5000
+DB_URI=<local MongoDB connection string>
+JWT_SECRET=<local development secret>
+```
+
+Use safe local-only values. Do not copy production, staging, personal account, or external service secrets into the repository.
+
+Check masked environment loading with:
+
+```bash
+npm run load-env
+```
+
+The integration tests use `mongodb-memory-server`, so they do not require a local Docker MongoDB container.
+
+## Branch Workflow
+
+Developers must not commit or push directly to `main`. The expected workflow is:
+
+```text
+Update local main
+Create a feature branch
+Make focused changes
+Run local checks
+Commit using Commitizen
+Push the feature branch
+Open a pull request into main
+Wait for CI
+Resolve review comments
+Merge through GitHub
+```
+
+Start every change from an up-to-date `main`:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c feature/add-refresh-tokens
+```
+
+## Branch Naming
+
+Use short, descriptive branch names with a type prefix:
+
+```text
+feature/add-refresh-tokens
+fix/token-expiry-validation
+docs/update-api-reference
+test/add-login-edge-cases
+ci/update-quality-gate
+refactor/extract-token-service
+```
+
+Prefer one focused purpose per branch. Avoid mixing unrelated refactors, documentation rewrites, dependency updates, and feature work in the same pull request.
+
+## Conventional Commits and Commitizen
+
+AuthMS uses Conventional Commits through Commitizen and commitlint.
+
+Use Commitizen for normal commits by running:
+
+```bash
+git commit
+```
+
+The Husky `prepare-commit-msg` hook attempts to open Commitizen when no commit message is supplied.
+
+If you provide a message manually, commitlint still checks it:
+
+```bash
+git commit -m "fix: handle expired jwt verification"
+```
+
+Common commit types:
+
+- `feat:` for user-visible or API features
+- `fix:` for bug fixes
+- `docs:` for documentation-only changes
+- `test:` for test-only changes
+- `ci:` for workflow changes
+- `refactor:` for behavior-preserving code changes
+- `chore:` for maintenance tasks
+
+Release commits are created with:
+
+```bash
+npm run release
+```
+
+## Coding and Formatting Standards
+
+Use the existing TypeScript, ESM, Express, controller-service-repository, and Jest patterns already present in the repository.
+
+Before opening a pull request:
+
+```bash
+npm run lint
+npm run build
+```
+
+To apply automatic formatting and safe lint fixes:
+
+```bash
+npm run lint:fix
+npm run format
+```
+
+Keep code focused and readable:
+
+- Add validation and tests for behavior changes.
+- Avoid unrelated refactoring.
+- Keep comments useful and specific.
+- Do not log secrets, passwords, full database URIs, tokens, or private configuration.
+- Never return password hashes in API responses.
+
+## Required Local Checks
+
+Run the checks that match your change. For most code changes, run the full local quality gate:
+
+```bash
+npm run lint
+npm run build
+npm run test:unit
+npm run test:integration
+npm audit --audit-level=critical
+docker compose build
+```
+
+For documentation changes, also validate the MkDocs site:
+
+```bash
+python -m pip install -r requirements-docs.txt
+mkdocs build --strict
+```
+
+If a command cannot be run locally, explain why in the pull request.
+
+## Documentation Expectations
+
+Update documentation when behavior, setup, environment variables, endpoints, commands, CI, Docker behavior, security guidance, or release workflow changes.
+
+Useful places to update:
+
+- `README.md` for repository-level setup and quick-start information
+- `docs/api/reference.md` and `docs/api/openapi.yaml` for API behavior
+- `docs/development/*.md` for developer workflows
+- `docs/security/overview.md` and `SECURITY.md` for security expectations
+
+Documentation should use placeholders for secrets and credentials.
+
+## Pull Requests
+
+Push your branch and open a pull request into `main`:
+
+```bash
+git push -u origin feature/add-refresh-tokens
+```
+
+Complete the pull request template with:
+
+- A concise summary
+- Related issue or context
+- Type of change
+- Implementation notes
+- Testing completed
+- Security considerations
+- Documentation changes
+- Reviewer notes
+
+Keep pull requests small enough to review carefully.
+
+## CI Quality Gate
+
+The main CI workflow runs for:
+
+- Pull requests targeting `main`
+- Pushes or merges into `main`
+- Manual runs through `workflow_dispatch`
+
+CI installs dependencies, validates linting, builds TypeScript, validates documentation, runs unit tests, runs integration tests, audits critical vulnerabilities, and builds the Docker image.
+
+The workflow reports the `CI / CI quality gate` status check. A GitHub branch ruleset or branch protection rule must separately require that status check before merging.
+
+## Review and Merge Rules
+
+Do not merge through local pushes to `main`. Merge through GitHub after:
+
+- CI has completed successfully
+- Review comments have been addressed
+- The pull request remains focused on the described change
+- The diff contains no real secrets or accidental `.env` files
+
+Do not claim that approval is mandatory unless the current GitHub repository rules require it. If GitHub requires approval or specific status checks, follow the repository settings shown on the pull request.
+
+## Security Vulnerability Reporting
+
+Do not open a public issue for exploitable security bugs, leaked credentials, tokens, database URIs, or private configuration.
+
+Follow `SECURITY.md` and report privately to the maintainer with safe reproduction details.
+
+If a secret is exposed, rotate it first. Removing it from code is not enough.
+
+## Release Responsibilities
+
+AuthMS uses `standard-version` for release metadata and changelog updates.
+
+Release work should happen from an up-to-date `main` after the relevant pull requests have merged. Create release changes on a branch, open a pull request, and merge through GitHub.
+
+Before release:
+
+```bash
+npm run lint
+npm run build
+npm run test:unit
+npm run test:integration
+npm audit --audit-level=critical
+docker compose build
+```
+
+Create release metadata with:
+
+```bash
+npm run release
+```
+
+Use semantic versioning:
+
+- Patch for bug fixes and documentation-only release updates
+- Minor for backward-compatible feature additions
+- Major for breaking API, persistence, or operational changes
+
+Review `CHANGELOG.md`, `package.json`, and `package-lock.json` before merging the release pull request. Tags should point at the final release commit on `main`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Amin
+Copyright (c) 2025 Muhammad Karim
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting and secret-handling g
 
 ## Further Documentation
 
+- [Contributing Guide](CONTRIBUTING.md)
 - [Architecture Overview](docs/architecture/overview.md)
 - [API Reference](docs/api/reference.md)
 - [OpenAPI Specification](docs/api/openapi.yaml)

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,130 @@
+# Contributing Workflow
+
+AuthMS uses a pull-request workflow so changes can be checked by automation and reviewed before they become part of `main`.
+
+## Why Main Is Protected
+
+`main` represents the latest accepted state of AuthMS. It should stay buildable, testable, and releasable.
+
+Direct commits to `main` are blocked locally by the Husky pre-commit hook. GitHub repository rules or branch protection should also be configured to prevent direct pushes and require the `CI / CI quality gate` status check before merge.
+
+Protection matters because AuthMS owns authentication behavior. Small mistakes can affect login, token verification, password safety, or downstream services that depend on bearer-token checks.
+
+## Why Feature Branches Are Used
+
+Feature branches keep work isolated until it is ready. They make it easier to:
+
+- Review one focused change at a time
+- Run CI before merge
+- Discuss implementation details without blocking `main`
+- Abandon or rewrite a change without disturbing released code
+- Keep release notes and history understandable
+
+Use branch names that describe the change, such as:
+
+```text
+feature/add-refresh-tokens
+fix/token-expiry-validation
+docs/update-api-reference
+test/add-login-edge-cases
+ci/update-quality-gate
+refactor/extract-token-service
+```
+
+## Pull Requests And CI
+
+Open pull requests into `main`. The CI workflow runs automatically for pull requests targeting `main`.
+
+The quality gate validates:
+
+```bash
+npm run lint
+npm run build
+mkdocs build --strict
+npm run test:unit
+npm run test:integration
+npm audit --audit-level=critical
+docker compose build
+```
+
+CI uses test-only environment values and `mongodb-memory-server` for integration tests. It does not need real production or development credentials.
+
+The workflow reports the `CI / CI quality gate` status check. GitHub branch rules decide whether that check blocks the merge button.
+
+## How Concurrency Helps
+
+The CI workflow has a concurrency group based on the workflow name and either the pull request number or branch ref. When you push a newer commit to the same pull request, GitHub cancels older in-progress runs for that pull request.
+
+That keeps feedback relevant. Reviewers and developers should focus on the newest CI run, not older runs from commits that are no longer current.
+
+The documentation publishing workflow uses a separate Pages concurrency group. It avoids overlapping Pages deployments when documentation changes are merged into `main`.
+
+## When CI Fails
+
+Start with the first failed step in the workflow log. Later failures may be side effects.
+
+Common responses:
+
+- Lint failure: run `npm run lint` locally, then `npm run lint:fix` if the issue is auto-fixable.
+- TypeScript failure: run `npm run build` and fix the reported type or compile error.
+- Unit test failure: run `npm run test:unit` and check the failing assertion.
+- Integration test failure: run `npm run test:integration`; remember that tests use in-memory MongoDB.
+- Documentation failure: run `mkdocs build --strict` and fix broken navigation, links, or MkDocs configuration.
+- Audit failure: review the critical vulnerability and update or replace the affected dependency.
+- Docker failure: run `docker compose build` and inspect the failed Dockerfile or Compose step.
+
+Push another commit after fixing the problem. The older CI run should be cancelled and replaced by a newer run.
+
+## Updating A Branch From Main
+
+Update your local `main`:
+
+```bash
+git switch main
+git pull --ff-only
+```
+
+Then update your feature branch:
+
+```bash
+git switch feature/add-refresh-tokens
+git merge main
+```
+
+Resolve conflicts carefully, then rerun the checks that match the changed files. If the team prefers rebasing for a specific pull request, rebase only when it is safe for everyone using the branch.
+
+## After A Pull Request Merges
+
+After GitHub merges the pull request:
+
+```bash
+git switch main
+git pull --ff-only
+git branch -d feature/add-refresh-tokens
+```
+
+If GitHub did not delete the remote branch automatically, remove it manually:
+
+```bash
+git push origin --delete feature/add-refresh-tokens
+```
+
+Do not delete a branch that another developer is still using.
+
+## Documentation Validation And Publishing
+
+Documentation changes are validated in two places:
+
+- The CI quality gate runs `mkdocs build --strict` before pull requests merge.
+- The documentation workflow runs after relevant documentation changes are pushed or merged into `main`.
+
+Local validation uses:
+
+```bash
+python -m pip install -r requirements-docs.txt
+mkdocs build --strict
+```
+
+The documentation publishing workflow builds the MkDocs site, uploads the Pages artifact, and deploys it through GitHub Pages. This publishes documentation only; it does not deploy AuthMS application code.
+
+Keep `mkdocs.yml` navigation, `docs/index.md`, and any affected topic pages in sync so the published documentation remains easy to browse.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ AuthMS is the authentication microservice for Maktab Pro. It provides user regis
 - [Architecture overview](architecture/overview.md)
 - [API reference](api/reference.md)
 - [Database collections](database/collections.md)
+- [Contributing workflow](development/contributing.md)
 - [Docker development](development/docker.md)
 - [Testing strategy](development/testing.md)
 - [Continuous integration](development/ci.md)
@@ -70,7 +71,7 @@ The machine-readable API contract is maintained in `api/openapi.yaml`.
 
 Developers should use feature branches and submit changes through pull requests into `main`. The CI quality gate validates linting, compilation, tests, dependency security and the Docker build before changes can be merged.
 
-See the [continuous integration guide](development/ci.md) for details.
+See the [contributing workflow](development/contributing.md) and [continuous integration guide](development/ci.md) for details.
 
 ## Security
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,13 +19,13 @@ theme:
     - content.code.copy
 
   palette:
-    - media: "(prefers-color-scheme: light)"
+    - media: '(prefers-color-scheme: light)'
       scheme: default
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
 
-    - media: "(prefers-color-scheme: dark)"
+    - media: '(prefers-color-scheme: dark)'
       scheme: slate
       toggle:
         icon: material/brightness-4
@@ -56,6 +56,7 @@ nav:
       - Collections: database/collections.md
 
   - Development:
+      - Contributing: development/contributing.md
       - Continuous Integration: development/ci.md
       - Docker: development/docker.md
       - Testing: development/testing.md


### PR DESCRIPTION
**Summary**

Adds professional contributor documentation for AuthMS and introduces a GitHub pull request template to standardise contribution workflow, review expectations, and local validation.

**Changes**

- Added root `CONTRIBUTING.md` with:
  - local setup and environment guidance
  - branch workflow and naming conventions
  - Conventional Commits and Commitizen usage
  - required local checks
  - documentation expectations
  - PR, CI, review, security, and release responsibilities
- Added `.github/pull_request_template.md` with a concise backend-focused checklist
- Added MkDocs contributor workflow page at `docs/development/contributing.md`
- Updated `mkdocs.yml` navigation to include the new contributing page
- Updated `docs/index.md` and `README.md` to link to contributor documentation

**Validation**

- `npm.cmd run build` passed
- `npm.cmd run test:unit` passed, 5 suites / 23 tests
- `npm.cmd run test:integration` passed, 1 suite / 8 tests
- `docker run --rm -v "${PWD}:/docs" squidfunk/mkdocs-material:9 build --strict` passed
- `npx.cmd prettier --check ...` passed
- `git diff --check` passed
- `npx.cmd eslint src scripts --ext .ts` passed with 0 errors and 9 existing `no-console` warnings

**Notes**

- `npm.cmd run lint` timed out locally, so a focused ESLint check was run against `src` and `scripts`.
- No application code was changed.